### PR TITLE
Fix stage progress and substage display in operations view

### DIFF
--- a/Kanstraction/Views/OperationsView.xaml.cs
+++ b/Kanstraction/Views/OperationsView.xaml.cs
@@ -330,35 +330,78 @@ public partial class OperationsView : UserControl
         }
     }
 
+    private static decimal CompletionValue(WorkStatus status) =>
+        status == WorkStatus.Finished || status == WorkStatus.Paid || status == WorkStatus.Stopped ? 1m : 0m;
+
     private static int ComputeBuildingProgress(Building b)
     {
-        // Your rule: NotStarted/Ongoing = 0; Finished/Paid/Stopped = 1
-        static decimal StatusVal(WorkStatus s) =>
-            (s == WorkStatus.Finished || s == WorkStatus.Paid || s == WorkStatus.Stopped) ? 1m : 0m;
-
         if (b.Stages == null || b.Stages.Count == 0)
-            return (int)(StatusVal(b.Status) * 100m);
+            return (int)Math.Round(CompletionValue(b.Status) * 100m, MidpointRounding.AwayFromZero);
 
         decimal perStageWeight = 1m / b.Stages.Count;
         decimal sum = 0m;
 
         foreach (var s in b.Stages.OrderBy(s => s.OrderIndex))
         {
+            decimal stageFraction;
+
             if (s.SubStages == null || s.SubStages.Count == 0)
             {
-                sum += perStageWeight * StatusVal(s.Status);
-                continue;
+                stageFraction = CompletionValue(s.Status);
+            }
+            else
+            {
+                stageFraction = ComputeStageProgress(s) / 100m;
             }
 
-            decimal perSub = 1m / s.SubStages.Count;
-            decimal stageSum = 0m;
-
-            foreach (var ss in s.SubStages.OrderBy(ss => ss.OrderIndex))
-                stageSum += perSub * StatusVal(ss.Status);
-
-            sum += perStageWeight * stageSum;
+            sum += perStageWeight * stageFraction;
         }
+
         return (int)Math.Round(sum * 100m, MidpointRounding.AwayFromZero);
+    }
+
+    private static int ComputeStageProgress(Stage stage)
+    {
+        if (stage.SubStages == null || stage.SubStages.Count == 0)
+            return (int)Math.Round(CompletionValue(stage.Status) * 100m, MidpointRounding.AwayFromZero);
+
+        var orderedSubs = stage.SubStages
+            .OrderBy(ss => ss.OrderIndex)
+            .ToList();
+
+        if (orderedSubs.Count == 0)
+            return (int)Math.Round(CompletionValue(stage.Status) * 100m, MidpointRounding.AwayFromZero);
+
+        decimal perSub = 1m / orderedSubs.Count;
+        decimal sum = 0m;
+
+        foreach (var ss in orderedSubs)
+            sum += perSub * CompletionValue(ss.Status);
+
+        return (int)Math.Round(sum * 100m, MidpointRounding.AwayFromZero);
+    }
+
+    private static string ComputeCurrentSubStageName(Stage stage)
+    {
+        if (stage.SubStages == null || stage.SubStages.Count == 0)
+            return string.Empty;
+
+        var orderedSubs = stage.SubStages
+            .OrderBy(ss => ss.OrderIndex)
+            .ToList();
+
+        if (orderedSubs.Count == 0)
+            return string.Empty;
+
+        var ongoing = orderedSubs.FirstOrDefault(ss => ss.Status == WorkStatus.Ongoing);
+        if (ongoing != null)
+            return ongoing.Name;
+
+        var next = orderedSubs.FirstOrDefault(ss => ss.Status == WorkStatus.NotStarted);
+        if (next != null)
+            return next.Name;
+
+        return orderedSubs.Last().Name;
     }
 
     private static string ComputeCurrentStageName(Building b)
@@ -670,25 +713,39 @@ public partial class OperationsView : UserControl
     private async Task ReloadStagesAndSubStagesAsync(int buildingId, int? preferredStageId = null)
     {
         // Reload stages for buildingId
-        var stages = await _db.Stages
+        var stageEntities = await _db.Stages
             .Where(s => s.BuildingId == buildingId)
             .OrderBy(s => s.OrderIndex)
+            .Include(s => s.SubStages)
             .AsNoTracking()
             .ToListAsync();
-        StagesGrid.ItemsSource = stages;
+
+        var stageRows = stageEntities
+            .Select(s => new
+            {
+                s.Id,
+                s.Name,
+                s.Status,
+                ProgressPercent = ComputeStageProgress(s),
+                OngoingSubStageName = ComputeCurrentSubStageName(s)
+            })
+            .ToList();
+
+        StagesGrid.ItemsSource = stageRows;
 
         // Select preferred stage (or first)
-        int stageId = preferredStageId ?? stages.FirstOrDefault()?.Id ?? 0;
+        int stageId = preferredStageId ?? stageRows.FirstOrDefault()?.Id ?? 0;
 
         if (stageId == 0)
         {
+            StagesGrid.SelectedItem = null;
             SubStagesGrid.ItemsSource = null;
             MaterialsGrid.ItemsSource = null;
             _currentStageId = null;
             return;
         }
 
-        var stageToSelect = stages.FirstOrDefault(s => s.Id == stageId);
+        var stageToSelect = stageRows.FirstOrDefault(s => s.Id == stageId);
         if (stageToSelect != null)
         {
             StagesGrid.SelectedItem = stageToSelect;


### PR DESCRIPTION
## Summary
- compute and bind stage progress and current sub-stage data when loading stages
- share completion helper logic and reuse it for building and stage progress calculations

## Testing
- `dotnet build Kanstraction/Kanstraction.csproj` *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8653f6784832d8c670dfd24ea88f6