### PR TITLE
Fix stage preset sub-stage order refresh

### DIFF
--- a/Kanstraction/ViewModels/StagePresetDesignerView.xaml.cs
+++ b/Kanstraction/ViewModels/StagePresetDesignerView.xaml.cs
@@ -333,6 +333,7 @@ public partial class StagePresetDesignerView : UserControl
         {
             s.OrderIndex = i++;
         }
+        SubStagesGrid?.Items.Refresh();
     }
 
     private void EmptyStateCreateNew_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
## Summary
- refresh the StagePresetDesignerView grid after reindexing sub-stages so the order numbers stay unique in the UI

## Testing
- dotnet build Kanstraction.csproj *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c8f850f4e0832d9cd573bc0e4c01c9