### PR TITLE
Prompt before saving operations data grid edits

### DIFF
--- a/Kanstraction/Resources/StringResources.fr.xaml
+++ b/Kanstraction/Resources/StringResources.fr.xaml
@@ -138,6 +138,10 @@
     <sys:String x:Key="OperationsView_UsageDate">Date d'utilisation</sys:String>
     <sys:String x:Key="OperationsView_UnitPrice">Prix unitaire</sys:String>
     <sys:String x:Key="OperationsView_Total">Total</sys:String>
+    <sys:String x:Key="OperationsView_ConfirmChangeTitle">Confirmer la modification</sys:String>
+    <sys:String x:Key="OperationsView_ReturnToDefault">Revenir à la valeur par défaut</sys:String>
+    <sys:String x:Key="OperationsView_ConfirmLaborChangeMessage">Êtes-vous sûr de vouloir changer la main-d'œuvre de {0} à {1} ?</sys:String>
+    <sys:String x:Key="OperationsView_ConfirmMaterialChangeMessage">Êtes-vous sûr de vouloir changer la quantité de {0} à {1} ?</sys:String>
     <sys:String x:Key="OperationsView_SelectProjectPrompt">Sélectionnez un projet</sys:String>
     <sys:String x:Key="OperationsView_LaborCostNegative">Le coût de main-d'œuvre ne peut pas être négatif.</sys:String>
     <sys:String x:Key="OperationsView_QuantityNegative">La quantité ne peut pas être négative.</sys:String>

--- a/Kanstraction/Resources/StringResources.xaml
+++ b/Kanstraction/Resources/StringResources.xaml
@@ -140,6 +140,10 @@
     <sys:String x:Key="OperationsView_UsageDate">Usage Date</sys:String>
     <sys:String x:Key="OperationsView_UnitPrice">Unit Price</sys:String>
     <sys:String x:Key="OperationsView_Total">Total</sys:String>
+    <sys:String x:Key="OperationsView_ConfirmChangeTitle">Confirm change</sys:String>
+    <sys:String x:Key="OperationsView_ReturnToDefault">Return to default</sys:String>
+    <sys:String x:Key="OperationsView_ConfirmLaborChangeMessage">Are you sure you want to change the labor from {0} to {1}?</sys:String>
+    <sys:String x:Key="OperationsView_ConfirmMaterialChangeMessage">Are you sure you want to change the quantity from {0} to {1}?</sys:String>
     <sys:String x:Key="OperationsView_SelectProjectPrompt">Select a project</sys:String>
     <sys:String x:Key="OperationsView_LaborCostNegative">Labor cost cannot be negative.</sys:String>
     <sys:String x:Key="OperationsView_QuantityNegative">Quantity cannot be negative.</sys:String>

--- a/Kanstraction/Views/ConfirmValueChangeDialog.xaml
+++ b/Kanstraction/Views/ConfirmValueChangeDialog.xaml
@@ -1,0 +1,34 @@
+<Window x:Class="Kanstraction.Views.ConfirmValueChangeDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="{DynamicResource OperationsView_ConfirmChangeTitle}"
+        WindowStartupLocation="CenterOwner"
+        ResizeMode="NoResize"
+        ShowInTaskbar="False"
+        WindowStyle="ToolWindow"
+        Width="400"
+        SizeToContent="Height">
+    <Grid Margin="16">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*"/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <TextBlock x:Name="MessageText"
+                   TextWrapping="Wrap"
+                   FontSize="14"
+                   Margin="0,0,0,12"/>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" HorizontalAlignment="Right">
+            <Button x:Name="BtnReturnToDefault"
+                    Width="150"
+                    Margin="0,0,8,0"
+                    IsCancel="True"
+                    Click="ReturnToDefault_Click"/>
+            <Button x:Name="BtnSave"
+                    Width="110"
+                    IsDefault="True"
+                    Click="Save_Click"/>
+        </StackPanel>
+    </Grid>
+</Window>

--- a/Kanstraction/Views/ConfirmValueChangeDialog.xaml.cs
+++ b/Kanstraction/Views/ConfirmValueChangeDialog.xaml.cs
@@ -1,0 +1,26 @@
+using System.Windows;
+
+namespace Kanstraction.Views;
+
+public partial class ConfirmValueChangeDialog : Window
+{
+    public ConfirmValueChangeDialog(string title, string message, string confirmText, string revertText)
+    {
+        InitializeComponent();
+
+        Title = title;
+        MessageText.Text = message;
+        BtnSave.Content = confirmText;
+        BtnReturnToDefault.Content = revertText;
+    }
+
+    private void Save_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = true;
+    }
+
+    private void ReturnToDefault_Click(object sender, RoutedEventArgs e)
+    {
+        DialogResult = false;
+    }
+}

--- a/Kanstraction/Views/OperationsView.xaml
+++ b/Kanstraction/Views/OperationsView.xaml
@@ -256,8 +256,9 @@
                 ScrollViewer.VerticalScrollBarVisibility="Auto"
                 ScrollViewer.CanContentScroll="True"
                 EnableRowVirtualization="True"
-                SelectionChanged="SubStagesGrid_SelectionChanged" 
-                CellEditEnding="SubStagesGrid_CellEditEnding" 
+                SelectionChanged="SubStagesGrid_SelectionChanged"
+                CellEditEnding="SubStagesGrid_CellEditEnding"
+                PreparingCellForEdit="SubStagesGrid_PreparingCellForEdit"
                 Style="{StaticResource MaterialDesignDataGrid}">
                     <DataGrid.Columns>
                     <DataGridTextColumn IsReadOnly="True" Header="{DynamicResource OperationsView_Name}" Binding="{Binding Name}"/>
@@ -382,7 +383,8 @@
                 ScrollViewer.CanContentScroll="True"
                 EnableRowVirtualization="True"
                 Style="{StaticResource MaterialDesignDataGrid}"
-                CellEditEnding="MaterialsGrid_CellEditEnding">
+                CellEditEnding="MaterialsGrid_CellEditEnding"
+                PreparingCellForEdit="MaterialsGrid_PreparingCellForEdit">
                 <DataGrid.Columns>
                     <DataGridTextColumn IsReadOnly="True" Header="{DynamicResource OperationsView_MaterialHeader}" Binding="{Binding Material.Name}"/>
                     <DataGridTextColumn Header="{DynamicResource OperationsView_Qty}" Width="100" IsReadOnly="False"


### PR DESCRIPTION
## Summary
- add a confirmation dialog that asks users to confirm labor and material quantity edits with Save or Return to default options before persisting changes
- capture original grid values so cancelling restores the previous value instead of saving
- add localized resources for the new confirmation dialog text and actions

## Testing
- `dotnet build Kanstraction/Kanstraction.csproj` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c92d244478832d81c454eff62c5da8