### PR TITLE
Disable SQLite pooling when using the EF context

### DIFF
--- a/Kanstraction/Data/AppDbContext.cs
+++ b/Kanstraction/Data/AppDbContext.cs
@@ -1,4 +1,5 @@
-﻿using Kanstraction.Entities;
+using Kanstraction.Entities;
+using Microsoft.Data.Sqlite;
 using Microsoft.EntityFrameworkCore;
 using System.IO;
 
@@ -35,7 +36,18 @@ public class AppDbContext : DbContext
     }
 
     protected override void OnConfiguring(DbContextOptionsBuilder options)
-        => options.UseSqlite($"Data Source={DbPath}");
+        => options.UseSqlite(BuildConnectionString(DbPath));
+
+    private static string BuildConnectionString(string path)
+    {
+        var builder = new SqliteConnectionStringBuilder
+        {
+            DataSource = path,
+            Pooling = false
+        };
+
+        return builder.ToString();
+    }
 
     protected override void OnModelCreating(ModelBuilder b)
     {


### PR DESCRIPTION
## Summary
- update the application DbContext to build its connection string with SQLite connection pooling disabled
- ensure entity framework uses the same connection string helper so file handles are released before backup restore

## Testing
- `dotnet build Kanstraction.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68c99c9722a8832da6e8da7aa3fc5c66