### PR TITLE
Fix project list refresh after restoring backup

### DIFF
--- a/Kanstraction/MainWindow.xaml.cs
+++ b/Kanstraction/MainWindow.xaml.cs
@@ -338,6 +338,8 @@ public partial class MainWindow : Window
     {
         if (_db == null || ProjectsList == null || _isRestoring) return;
 
+        var previouslySelectedId = (ProjectsList.SelectedItem as Project)?.Id;
+
         _allProjects = await _db.Projects
             .AsNoTracking()
             .OrderBy(p => p.Name)
@@ -345,11 +347,32 @@ public partial class MainWindow : Window
 
         ProjectsList.ItemsSource = _allProjects;
 
-        if (_allProjects.Count > 0)
+        if (_activeView != ActiveView.Operations)
         {
-            if (ProjectsList.SelectedItem == null)
-                ProjectsList.SelectedIndex = 0;
+            ProjectsList.SelectedItem = null;
+            ProjectsList.SelectedIndex = -1;
+            return;
         }
+
+        if (_allProjects.Count == 0)
+        {
+            ProjectsList.SelectedItem = null;
+            ProjectsList.SelectedIndex = -1;
+            return;
+        }
+
+        if (previouslySelectedId.HasValue)
+        {
+            var match = _allProjects.FirstOrDefault(p => p.Id == previouslySelectedId.Value);
+            if (match != null)
+            {
+                ProjectsList.SelectedItem = match;
+                return;
+            }
+        }
+
+        if (ProjectsList.SelectedItem == null)
+            ProjectsList.SelectedIndex = 0;
     }
 
     private Task PrepareForRestoreAsync()
@@ -362,6 +385,8 @@ public partial class MainWindow : Window
 
         _allProjects.Clear();
         ProjectsList.ItemsSource = null;
+        ProjectsList.SelectedItem = null;
+        ProjectsList.SelectedIndex = -1;
 
         return Task.CompletedTask;
     }


### PR DESCRIPTION
## Summary
- avoid auto-selecting projects while viewing the backup hub so a restore no longer preloads the operations view with an empty selection
- retain or restore the selected project when returning to the operations view after refreshing the project list
- clear the project selection while a restore is in progress to ensure the next activation of the operations view reloads data

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a2f75024832d9ebdf61d7927cf1f