### PR TITLE
Fix project list refresh after database restore

### DIFF
--- a/Kanstraction/MainWindow.xaml.cs
+++ b/Kanstraction/MainWindow.xaml.cs
@@ -334,9 +334,9 @@ public partial class MainWindow : Window
         }
     }
 
-    private async Task RefreshProjectsList()
+    private async Task RefreshProjectsList(bool ignoreRestoringGuard = false)
     {
-        if (_db == null || ProjectsList == null || _isRestoring) return;
+        if (_db == null || ProjectsList == null || (_isRestoring && !ignoreRestoringGuard)) return;
 
         var previouslySelectedId = (ProjectsList.SelectedItem as Project)?.Id;
 
@@ -398,7 +398,7 @@ public partial class MainWindow : Window
             InitializeDataLayer();
             BuildViews();
             ShowActiveView();
-            await RefreshProjectsList();
+            await RefreshProjectsList(ignoreRestoringGuard: true);
         }
         finally
         {


### PR DESCRIPTION
## Summary
- allow the project list reload helper to bypass the restore guard when needed
- force a refresh after rebuilding the data context so restored projects immediately appear

## Testing
- dotnet build *(fails: `dotnet`: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9a865cd74832d8df3b574c91fef20