### PR TITLE
Ensure SQLite backup sidecars are cleaned up

### DIFF
--- a/Kanstraction/Services/BackupService.cs
+++ b/Kanstraction/Services/BackupService.cs
@@ -183,7 +183,21 @@ public class BackupService
             using var destination = new SqliteConnection(destinationConnectionString);
             destination.Open();
 
-            source.BackupDatabase(destination);
+            try
+            {
+                source.BackupDatabase(destination);
+            }
+            finally
+            {
+                TryDeleteFile($"{destinationFullPath}-wal");
+                TryDeleteFile($"{destinationFullPath}-shm");
+
+                if (!string.Equals(sourceFullPath, _dbPath, StringComparison.OrdinalIgnoreCase))
+                {
+                    TryDeleteFile($"{sourceFullPath}-wal");
+                    TryDeleteFile($"{sourceFullPath}-shm");
+                }
+            }
         }).ConfigureAwait(false);
     }
 


### PR DESCRIPTION
## Summary
- wrap the SQLite backup operation in a try/finally to guarantee cleanup
- remove -wal and -shm companions for the destination and, when applicable, the source database

## Testing
- unable to run manual backup/restore verification because the .NET SDK is unavailable in the container (network access to install it is blocked)


------
https://chatgpt.com/codex/tasks/task_e_68ca32b1cf7c832db9672672fbacfd3b