### PR TITLE
Ensure WAL files are deleted after backup

### DIFF
--- a/Kanstraction/Services/BackupService.cs
+++ b/Kanstraction/Services/BackupService.cs
@@ -177,18 +177,24 @@ public class BackupService
                 Pooling = false
             }.ToString();
 
-            using var source = new SqliteConnection(sourceConnectionString);
-            source.Open();
-
-            using var destination = new SqliteConnection(destinationConnectionString);
-            destination.Open();
+            SqliteConnection? source = null;
+            SqliteConnection? destination = null;
 
             try
             {
+                source = new SqliteConnection(sourceConnectionString);
+                source.Open();
+
+                destination = new SqliteConnection(destinationConnectionString);
+                destination.Open();
+
                 source.BackupDatabase(destination);
             }
             finally
             {
+                destination?.Dispose();
+                source?.Dispose();
+
                 TryDeleteFile($"{destinationFullPath}-wal");
                 TryDeleteFile($"{destinationFullPath}-shm");
 


### PR DESCRIPTION
## Summary
- dispose of the SQLite connections before cleaning up the related WAL and SHM files so they can be removed after restore/backup operations

## Testing
- not run (dotnet CLI unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68ca59fd6a08832d961ea22e67881653