### PR TITLE
Simplify backup hub view

### DIFF
--- a/Kanstraction/MainWindow.xaml.cs
+++ b/Kanstraction/MainWindow.xaml.cs
@@ -103,7 +103,6 @@ public partial class MainWindow : Window
         try
         {
             await App.BackupService.CreateHourlyBackupAsync();
-            _backupView.RefreshBackupInfo();
         }
         catch
         {
@@ -194,7 +193,6 @@ public partial class MainWindow : Window
         _activeView = ActiveView.Backup;
         MainContentHost.Content = _backupView;
         CollapseExplorer();
-        _backupView.RefreshBackupInfo();
     }
 
     private void ShowActiveView()

--- a/Kanstraction/Resources/StringResources.fr.xaml
+++ b/Kanstraction/Resources/StringResources.fr.xaml
@@ -111,7 +111,7 @@
 
     <!-- BackupHubView -->
     <sys:String x:Key="BackupHubView_Title">Sauvegardes et restauration</sys:String>
-    <sys:String x:Key="BackupHubView_Intro">Gérez les sauvegardes manuelles et consultez l'emplacement des sauvegardes automatiques.</sys:String>
+    <sys:String x:Key="BackupHubView_Intro">Créez une sauvegarde manuelle ou restaurez à partir d'un fichier de sauvegarde.</sys:String>
     <sys:String x:Key="BackupHubView_AutomaticHeader">Sauvegardes automatiques</sys:String>
     <sys:String x:Key="BackupHubView_AutomaticDescription">L'application crée une sauvegarde au démarrage puis toutes les heures lorsqu'elle reste ouverte.</sys:String>
     <sys:String x:Key="BackupHubView_StartupFolderLabel">Dossier des sauvegardes au démarrage</sys:String>

--- a/Kanstraction/Resources/StringResources.xaml
+++ b/Kanstraction/Resources/StringResources.xaml
@@ -113,7 +113,7 @@
 
     <!-- BackupHubView -->
     <sys:String x:Key="BackupHubView_Title">Backups &amp; Restore</sys:String>
-    <sys:String x:Key="BackupHubView_Intro">Manage manual backups and review where automatic backups are stored.</sys:String>
+    <sys:String x:Key="BackupHubView_Intro">Create manual backups or restore from a saved backup file.</sys:String>
     <sys:String x:Key="BackupHubView_AutomaticHeader">Automatic backups</sys:String>
     <sys:String x:Key="BackupHubView_AutomaticDescription">The application creates backups on startup and every hour while it is open.</sys:String>
     <sys:String x:Key="BackupHubView_StartupFolderLabel">Startup backups folder</sys:String>

--- a/Kanstraction/Views/BackupHubView.xaml
+++ b/Kanstraction/Views/BackupHubView.xaml
@@ -4,60 +4,25 @@
              xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
              Background="{DynamicResource MaterialDesignPaper}">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
-        <StackPanel Margin="24">
-            <TextBlock Text="{DynamicResource BackupHubView_Title}" FontSize="20" FontWeight="SemiBold" />
-            <TextBlock Text="{DynamicResource BackupHubView_Intro}" Margin="0,8,0,20" TextWrapping="Wrap" />
+        <StackPanel Margin="24" HorizontalAlignment="Center">
+            <TextBlock Text="{DynamicResource BackupHubView_Title}"
+                       FontSize="20"
+                       FontWeight="SemiBold"
+                       HorizontalAlignment="Center" />
+            <TextBlock Text="{DynamicResource BackupHubView_Intro}"
+                       Margin="0,8,0,24"
+                       TextWrapping="Wrap"
+                       TextAlignment="Center" />
 
-            <Border Background="{DynamicResource MaterialDesignCardBackground}"
-                    BorderBrush="{DynamicResource MaterialDesignDivider}"
-                    BorderThickness="1"
-                    CornerRadius="8"
-                    Padding="16"
-                    Margin="0,0,0,16">
-                <StackPanel>
-                    <TextBlock Text="{DynamicResource BackupHubView_AutomaticHeader}" FontWeight="SemiBold" />
-                    <TextBlock Text="{DynamicResource BackupHubView_AutomaticDescription}" Margin="0,4,0,12" TextWrapping="Wrap" />
-
-                    <TextBlock Text="{DynamicResource BackupHubView_StartupFolderLabel}" FontWeight="SemiBold" />
-                    <TextBlock x:Name="StartupFolderText" Margin="0,0,0,8" TextWrapping="Wrap" />
-                    <TextBlock x:Name="LatestStartupBackupText" Margin="0,0,0,12" Foreground="{DynamicResource MaterialDesignBodySecondary}" />
-
-                    <TextBlock Text="{DynamicResource BackupHubView_HourlyFolderLabel}" FontWeight="SemiBold" />
-                    <TextBlock x:Name="HourlyFolderText" Margin="0,0,0,8" TextWrapping="Wrap" />
-                    <TextBlock x:Name="LatestHourlyBackupText" Foreground="{DynamicResource MaterialDesignBodySecondary}" />
-                </StackPanel>
-            </Border>
-
-            <Border Background="{DynamicResource MaterialDesignCardBackground}"
-                    BorderBrush="{DynamicResource MaterialDesignDivider}"
-                    BorderThickness="1"
-                    CornerRadius="8"
-                    Padding="16"
-                    Margin="0,0,0,16">
-                <StackPanel>
-                    <TextBlock Text="{DynamicResource BackupHubView_ManualHeader}" FontWeight="SemiBold" />
-                    <TextBlock Text="{DynamicResource BackupHubView_ManualDescription}" Margin="0,4,0,12" TextWrapping="Wrap" />
-                    <Button Content="{DynamicResource BackupHubView_CreateManualBackup}"
-                            Width="200"
-                            Style="{StaticResource MaterialDesignOutlinedButton}"
-                            Click="ManualBackup_Click" />
-                </StackPanel>
-            </Border>
-
-            <Border Background="{DynamicResource MaterialDesignCardBackground}"
-                    BorderBrush="{DynamicResource MaterialDesignDivider}"
-                    BorderThickness="1"
-                    CornerRadius="8"
-                    Padding="16">
-                <StackPanel>
-                    <TextBlock Text="{DynamicResource BackupHubView_RestoreHeader}" FontWeight="SemiBold" />
-                    <TextBlock Text="{DynamicResource BackupHubView_RestoreDescription}" Margin="0,4,0,12" TextWrapping="Wrap" />
-                    <Button Content="{DynamicResource BackupHubView_RestoreButton}"
-                            Width="220"
-                            Style="{StaticResource MaterialDesignOutlinedButton}"
-                            Click="RestoreBackup_Click" />
-                </StackPanel>
-            </Border>
+            <StackPanel HorizontalAlignment="Center" Width="240">
+                <Button Content="{DynamicResource BackupHubView_CreateManualBackup}"
+                        Margin="0,0,0,12"
+                        Style="{StaticResource MaterialDesignOutlinedButton}"
+                        Click="ManualBackup_Click" />
+                <Button Content="{DynamicResource BackupHubView_RestoreButton}"
+                        Style="{StaticResource MaterialDesignOutlinedButton}"
+                        Click="RestoreBackup_Click" />
+            </StackPanel>
         </StackPanel>
     </ScrollViewer>
 </UserControl>

--- a/Kanstraction/Views/BackupHubView.xaml.cs
+++ b/Kanstraction/Views/BackupHubView.xaml.cs
@@ -1,7 +1,6 @@
 using Kanstraction.Services;
 using Microsoft.Win32;
 using System.Globalization;
-using System.IO;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -24,31 +23,6 @@ public partial class BackupHubView : UserControl
         _backupService = backupService;
         _onBeforeRestoreAsync = onBeforeRestoreAsync;
         _onAfterRestoreAsync = onAfterRestoreAsync;
-        RefreshBackupInfo();
-    }
-
-    public void RefreshBackupInfo()
-    {
-        if (_backupService == null)
-            return;
-
-        StartupFolderText.Text = _backupService.StartupBackupsDirectory;
-        HourlyFolderText.Text = _backupService.HourlyBackupsDirectory;
-
-        LatestStartupBackupText.Text = FormatLatestInfo(_backupService.GetLatestStartupBackup());
-        LatestHourlyBackupText.Text = FormatLatestInfo(_backupService.GetLatestHourlyBackup());
-    }
-
-    private static string FormatLatestInfo(FileInfo? info)
-    {
-        if (info == null)
-        {
-            return ResourceHelper.GetString("BackupHubView_NoBackupYet", "No backups yet.");
-        }
-
-        var pattern = ResourceHelper.GetString("BackupHubView_LatestAutomaticFormat", "Latest backup: {0}");
-        var timestamp = info.LastWriteTime.ToString("G", CultureInfo.CurrentCulture);
-        return string.Format(CultureInfo.CurrentCulture, pattern, timestamp);
     }
 
     private async void ManualBackup_Click(object sender, RoutedEventArgs e)
@@ -76,8 +50,6 @@ public partial class BackupHubView : UserControl
                     ResourceHelper.GetString("Common_SuccessTitle", "Success"),
                     MessageBoxButton.OK,
                     MessageBoxImage.Information);
-
-                RefreshBackupInfo();
             }
             catch (Exception ex)
             {
@@ -174,7 +146,6 @@ public partial class BackupHubView : UserControl
                     ResourceHelper.GetString("Common_SuccessTitle", "Success"),
                     MessageBoxButton.OK,
                     MessageBoxImage.Information);
-                RefreshBackupInfo();
             }
         }
     }


### PR DESCRIPTION
## Summary
- remove the automatic backup information card from the backup hub view and center the manual and restore actions
- update the backup hub intro copy to reflect the simplified layout in both English and French
- drop the unused refresh logic now that the automatic backup status is no longer displayed

## Testing
- `dotnet build Kanstraction.sln` *(fails: command not found: dotnet)*

------
https://chatgpt.com/codex/tasks/task_e_68ca61bddd30832d84f5123340152cb2