### PR TITLE
Handle null selection when deleting sub stage

### DIFF
--- a/Kanstraction/ViewModels/StagePresetDesignerView.xaml.cs
+++ b/Kanstraction/ViewModels/StagePresetDesignerView.xaml.cs
@@ -273,16 +273,23 @@ public partial class StagePresetDesignerView : UserControl
         // adjust selection
         if (_subStages.Count > 0)
         {
-            SubStagesGrid.SelectedIndex = Math.Min(SubStagesGrid.SelectedIndex, _subStages.Count - 1);
-            _selectedSubStage = (SubStageVm)SubStagesGrid.SelectedItem;
-            MaterialsGrid.ItemsSource = _selectedSubStage.Materials;
+            var newIndex = SubStagesGrid.SelectedIndex;
+            if (newIndex < 0)
+            {
+                newIndex = 0;
+            }
+            if (newIndex >= _subStages.Count)
+            {
+                newIndex = _subStages.Count - 1;
+            }
+
+            SubStagesGrid.SelectedIndex = newIndex;
         }
         else
         {
-            _selectedSubStage = null;
-            MaterialsGrid.ItemsSource = new ObservableCollection<MaterialUsageVm>();
+            SubStagesGrid.SelectedIndex = -1;
         }
-        RefreshMaterialPickerItems();
+        UpdateSelectedSubStageFromGrid();
         UpdateMaterialsPanelVisibility();
         UpdateSummary();
         SetDirty();


### PR DESCRIPTION
## Summary
- ensure the stage preset designer reselects a valid sub-stage after removal
- reuse the selection sync helper to avoid dereferencing a null selected sub-stage

## Testing
- ⚠️ `dotnet build Kanstraction.sln` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd3d3b5688832db31be9a01a24c89e