### PR TITLE
Localize operation status labels

### DIFF
--- a/Kanstraction/Converters/WorkStatusToStringConverter.cs
+++ b/Kanstraction/Converters/WorkStatusToStringConverter.cs
@@ -1,0 +1,37 @@
+using Kanstraction;
+using Kanstraction.Entities;
+using System;
+using System.Globalization;
+using System.Windows.Data;
+
+namespace Kanstraction.Converters;
+
+public class WorkStatusToStringConverter : IValueConverter
+{
+    public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+    {
+        if (value is WorkStatus status)
+        {
+            var key = status switch
+            {
+                WorkStatus.NotStarted => "WorkStatus_NotStarted",
+                WorkStatus.Ongoing => "WorkStatus_Ongoing",
+                WorkStatus.Finished => "WorkStatus_Finished",
+                WorkStatus.Paid => "WorkStatus_Paid",
+                WorkStatus.Stopped => "WorkStatus_Stopped",
+                _ => null
+            };
+
+            if (key != null)
+            {
+                return ResourceHelper.GetString(key, status.ToString());
+            }
+
+            return status.ToString();
+        }
+
+        return value?.ToString() ?? string.Empty;
+    }
+
+    public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotSupportedException();
+}

--- a/Kanstraction/Resources/StringResources.fr.xaml
+++ b/Kanstraction/Resources/StringResources.fr.xaml
@@ -138,6 +138,11 @@
     <sys:String x:Key="BackupHubView_RestoreSuccess">Sauvegarde restaurée avec succès.</sys:String>
 
     <!-- OperationsView -->
+    <sys:String x:Key="WorkStatus_NotStarted">Non commencé</sys:String>
+    <sys:String x:Key="WorkStatus_Ongoing">En cours</sys:String>
+    <sys:String x:Key="WorkStatus_Finished">Terminé</sys:String>
+    <sys:String x:Key="WorkStatus_Paid">Payé</sys:String>
+    <sys:String x:Key="WorkStatus_Stopped">Arrêté</sys:String>
     <sys:String x:Key="OperationsView_ResolvePayment">Résoudre le paiement</sys:String>
     <sys:String x:Key="OperationsView_ResolvePaymentTooltip">Générer un PDF de résolution de paiement pour ce projet et marquer les éléments terminés comme payés</sys:String>
     <sys:String x:Key="OperationsView_Buildings">Bâtiments</sys:String>

--- a/Kanstraction/Resources/StringResources.xaml
+++ b/Kanstraction/Resources/StringResources.xaml
@@ -140,6 +140,11 @@
     <sys:String x:Key="BackupHubView_RestoreSuccess">Backup restored successfully.</sys:String>
 
     <!-- OperationsView -->
+    <sys:String x:Key="WorkStatus_NotStarted">Not Started</sys:String>
+    <sys:String x:Key="WorkStatus_Ongoing">Ongoing</sys:String>
+    <sys:String x:Key="WorkStatus_Finished">Finished</sys:String>
+    <sys:String x:Key="WorkStatus_Paid">Paid</sys:String>
+    <sys:String x:Key="WorkStatus_Stopped">Stopped</sys:String>
     <sys:String x:Key="OperationsView_ResolvePayment">Resolve Payment</sys:String>
     <sys:String x:Key="OperationsView_ResolvePaymentTooltip">Generate a payment resolution PDF for this project and mark finished items as Paid</sys:String>
     <sys:String x:Key="OperationsView_Buildings">Buildings</sys:String>

--- a/Kanstraction/Views/OperationsView.xaml
+++ b/Kanstraction/Views/OperationsView.xaml
@@ -10,6 +10,7 @@
 
     <UserControl.Resources>
         <conv:StatusToBrushConverter x:Key="StatusToBrush" />
+        <conv:WorkStatusToStringConverter x:Key="StatusToString" />
         <conv:TotalCostConverter x:Key="TotalCostConverter"/>
         <conv:NullToVisibilityConverter x:Key="NullToVisibilityConverter"/>
     </UserControl.Resources>
@@ -112,7 +113,7 @@
                             <DataTemplate>
                                 <Border CornerRadius="10" Padding="6,2"
                         Background="{Binding Status, Converter={StaticResource StatusToBrush}}">
-                                    <TextBlock Text="{Binding Status}" Foreground="White" FontWeight="SemiBold"/>
+                                    <TextBlock Text="{Binding Status, Converter={StaticResource StatusToString}}" Foreground="White" FontWeight="SemiBold"/>
                                 </Border>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
@@ -202,7 +203,7 @@
                             <DataTemplate>
                                 <Border CornerRadius="10" Padding="6,2"
                         Background="{Binding Status, Converter={StaticResource StatusToBrush}}">
-                                    <TextBlock Text="{Binding Status}" Foreground="White" FontWeight="SemiBold"/>
+                                    <TextBlock Text="{Binding Status, Converter={StaticResource StatusToString}}" Foreground="White" FontWeight="SemiBold"/>
                                 </Border>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
@@ -267,7 +268,7 @@
                             <DataTemplate>
                                 <Border CornerRadius="10" Padding="6,2"
                         Background="{Binding Status, Converter={StaticResource StatusToBrush}}">
-                                    <TextBlock Text="{Binding Status}" Foreground="White" FontWeight="SemiBold"/>
+                                    <TextBlock Text="{Binding Status, Converter={StaticResource StatusToString}}" Foreground="White" FontWeight="SemiBold"/>
                                 </Border>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>


### PR DESCRIPTION
## Summary
- add a value converter to translate work statuses through localized resources
- show localized status text inside colored badges in the operations view grids
- supply English and French resource strings for each work status value

## Testing
- `dotnet build Kanstraction.sln` *(fails: dotnet command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8273bff0832db7d547a573d4fb96