### PR TITLE
Disable DataGrid sorting in admin views

### DIFF
--- a/Kanstraction/ViewModels/StagePresetDesignerView.xaml
+++ b/Kanstraction/ViewModels/StagePresetDesignerView.xaml
@@ -101,7 +101,7 @@
                                 <TextBlock Grid.Row="0" Text="{DynamicResource AdminHubView_SubStages}" FontWeight="SemiBold" Margin="0,0,0,8"/>
 
                                 <DataGrid Grid.Row="1" x:Name="SubStagesGrid" Margin="0,0,0,8"
-                        AutoGenerateColumns="False" CanUserAddRows="False"
+                        AutoGenerateColumns="False" CanUserAddRows="False" CanUserSortColumns="False"
                         HeadersVisibility="Column" GridLinesVisibility="None"
                         SelectionMode="Single"
                         SelectionChanged="SubStagesGrid_SelectionChanged"
@@ -170,6 +170,7 @@
                                 </StackPanel>
 
                                 <DataGrid Grid.Row="2" x:Name="MaterialsGrid" AutoGenerateColumns="False" CanUserAddRows="False"
+                        CanUserSortColumns="False"
                         HeadersVisibility="Column" GridLinesVisibility="None"
                         Style="{StaticResource MaterialDesignDataGrid}">
                                     <DataGrid.Columns>

--- a/Kanstraction/Views/AdminHubView.xaml
+++ b/Kanstraction/Views/AdminHubView.xaml
@@ -103,6 +103,7 @@
 
                                 <TextBlock Text="{DynamicResource AdminHubView_PriceHistory}" FontWeight="SemiBold" Margin="0,0,0,8"/>
                                 <DataGrid x:Name="MatHistoryGrid" AutoGenerateColumns="False" IsReadOnly="True"
+                        CanUserSortColumns="False"
                         HeadersVisibility="Column" GridLinesVisibility="None"
                         Height="200" Margin="0,0,0,8"
                         Style="{StaticResource MaterialDesignDataGrid}">
@@ -306,7 +307,7 @@
                                         <DataGrid x:Name="BtAssignedGrid"
             Grid.Column="0"
             Height="300"
-            AutoGenerateColumns="False" CanUserAddRows="False"
+            AutoGenerateColumns="False" CanUserAddRows="False" CanUserSortColumns="False"
             HeadersVisibility="Column" GridLinesVisibility="None"
             SelectionChanged="BtAssignedGrid_SelectionChanged"
             Style="{StaticResource MaterialDesignDataGrid}">
@@ -369,7 +370,7 @@
 
                                                 <DataGrid x:Name="BtSubStagesPreviewGrid"
                 Grid.Row="1"
-                AutoGenerateColumns="False" CanUserAddRows="False"
+                AutoGenerateColumns="False" CanUserAddRows="False" CanUserSortColumns="False"
                 HeadersVisibility="Column" GridLinesVisibility="None"
                 IsReadOnly="True"
                 Style="{StaticResource MaterialDesignDataGrid}">


### PR DESCRIPTION
## Summary
- disable header-driven sorting for material history and building type grids in `AdminHubView`
- prevent `StagePresetDesignerView` sub-stage and material grids from allowing column reordering via header clicks

## Testing
- `dotnet build Kanstraction.sln` *(fails: `dotnet` not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd842e16e0832d9d054a43fbb66294