### PR TITLE
Highlight text boxes while editing

### DIFF
--- a/Kanstraction/App.xaml.cs
+++ b/Kanstraction/App.xaml.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
 using System.Windows;
+using Kanstraction.Behaviors;
 using Kanstraction.Data;
 using Kanstraction.Services;
 using Microsoft.EntityFrameworkCore;
@@ -14,6 +15,8 @@ public partial class App : Application
 
     protected override async void OnStartup(StartupEventArgs e)
     {
+        TextBoxEditHighlighter.Register();
+
         var culture = new CultureInfo("fr-FR");
         Thread.CurrentThread.CurrentCulture = culture;
         Thread.CurrentThread.CurrentUICulture = culture;

--- a/Kanstraction/Behaviors/TextBoxEditHighlighter.cs
+++ b/Kanstraction/Behaviors/TextBoxEditHighlighter.cs
@@ -1,0 +1,141 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Input;
+using System.Windows.Media;
+
+namespace Kanstraction.Behaviors;
+
+/// <summary>
+/// Applies a white background to any editable <see cref="TextBox"/> while it has keyboard focus
+/// so that edit mode is obvious across the application.
+/// </summary>
+public static class TextBoxEditHighlighter
+{
+    private enum StoredBackgroundKind
+    {
+        None,
+        LocalValue,
+        Binding
+    }
+
+    private static readonly DependencyProperty HighlightAppliedProperty = DependencyProperty.RegisterAttached(
+        "HighlightApplied",
+        typeof(bool),
+        typeof(TextBoxEditHighlighter),
+        new PropertyMetadata(false));
+
+    private static readonly DependencyProperty StoredBackgroundKindProperty = DependencyProperty.RegisterAttached(
+        "StoredBackgroundKind",
+        typeof(StoredBackgroundKind),
+        typeof(TextBoxEditHighlighter),
+        new PropertyMetadata(StoredBackgroundKind.None));
+
+    private static readonly DependencyProperty StoredBackgroundValueProperty = DependencyProperty.RegisterAttached(
+        "StoredBackgroundValue",
+        typeof(object),
+        typeof(TextBoxEditHighlighter));
+
+    private static bool _isRegistered;
+
+    public static void Register()
+    {
+        if (_isRegistered)
+        {
+            return;
+        }
+
+        EventManager.RegisterClassHandler(
+            typeof(TextBox),
+            UIElement.GotKeyboardFocusEvent,
+            new KeyboardFocusChangedEventHandler(OnTextBoxGotKeyboardFocus),
+            true);
+
+        EventManager.RegisterClassHandler(
+            typeof(TextBox),
+            UIElement.LostKeyboardFocusEvent,
+            new KeyboardFocusChangedEventHandler(OnTextBoxLostKeyboardFocus),
+            true);
+
+        _isRegistered = true;
+    }
+
+    private static void OnTextBoxGotKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+    {
+        if (sender is not TextBox textBox)
+        {
+            return;
+        }
+
+        if (textBox.IsReadOnly || !textBox.IsEnabled)
+        {
+            return;
+        }
+
+        if ((bool)textBox.GetValue(HighlightAppliedProperty))
+        {
+            return;
+        }
+
+        var binding = (BindingBase?)BindingOperations.GetBinding(textBox, Control.BackgroundProperty)
+                      ?? BindingOperations.GetMultiBinding(textBox, Control.BackgroundProperty)
+                      ?? BindingOperations.GetPriorityBinding(textBox, Control.BackgroundProperty);
+
+        if (binding != null)
+        {
+            textBox.SetValue(StoredBackgroundKindProperty, StoredBackgroundKind.Binding);
+            textBox.SetValue(StoredBackgroundValueProperty, binding.Clone());
+        }
+        else
+        {
+            var localValue = textBox.ReadLocalValue(Control.BackgroundProperty);
+            if (localValue != DependencyProperty.UnsetValue)
+            {
+                textBox.SetValue(StoredBackgroundKindProperty, StoredBackgroundKind.LocalValue);
+                textBox.SetValue(StoredBackgroundValueProperty, localValue);
+            }
+            else
+            {
+                textBox.SetValue(StoredBackgroundKindProperty, StoredBackgroundKind.None);
+                textBox.ClearValue(StoredBackgroundValueProperty);
+            }
+        }
+
+        textBox.SetValue(HighlightAppliedProperty, true);
+        textBox.SetValue(Control.BackgroundProperty, Brushes.White);
+    }
+
+    private static void OnTextBoxLostKeyboardFocus(object sender, KeyboardFocusChangedEventArgs e)
+    {
+        if (sender is not TextBox textBox)
+        {
+            return;
+        }
+
+        if (!(bool)textBox.GetValue(HighlightAppliedProperty))
+        {
+            return;
+        }
+
+        textBox.ClearValue(HighlightAppliedProperty);
+
+        var kind = (StoredBackgroundKind)textBox.GetValue(StoredBackgroundKindProperty);
+        var storedValue = textBox.GetValue(StoredBackgroundValueProperty);
+
+        textBox.ClearValue(StoredBackgroundKindProperty);
+        textBox.ClearValue(StoredBackgroundValueProperty);
+
+        switch (kind)
+        {
+            case StoredBackgroundKind.Binding when storedValue is BindingBase binding:
+                BindingOperations.SetBinding(textBox, Control.BackgroundProperty, binding);
+                break;
+            case StoredBackgroundKind.LocalValue:
+                textBox.SetValue(Control.BackgroundProperty, storedValue);
+                break;
+            default:
+                textBox.ClearValue(Control.BackgroundProperty);
+                break;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a TextBoxEditHighlighter class that sets a white background on editable text boxes while they have keyboard focus
- register the global highlighter during application startup so grids and forms show the edit state consistently

## Testing
- `dotnet build Kanstraction.sln` *(fails: dotnet CLI is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cd85e5227c832dbdb5f8cbdc399f80