### PR TITLE
Show historical material prices and set usage date on finish

### DIFF
--- a/Kanstraction/Entities/MaterialUsage.cs
+++ b/Kanstraction/Entities/MaterialUsage.cs
@@ -1,4 +1,6 @@
-﻿namespace Kanstraction.Entities;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Kanstraction.Entities;
 
 public class MaterialUsage
 {
@@ -8,6 +10,9 @@ public class MaterialUsage
     public decimal Qty { get; set; }
     public DateTime UsageDate { get; set; }
     public string? Notes { get; set; }
+
+    [NotMapped]
+    public decimal DisplayUnitPrice { get; set; }
 
     public SubStage SubStage { get; set; } = null!;
     public Material Material { get; set; } = null!;

--- a/Kanstraction/Views/OperationsView.xaml
+++ b/Kanstraction/Views/OperationsView.xaml
@@ -392,7 +392,7 @@
                         Binding="{Binding Qty, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.##}}"/>
                     <DataGridTextColumn IsReadOnly="True" Header="{DynamicResource OperationsView_Unit}" Binding="{Binding Material.Unit}"/>
                     <DataGridTextColumn IsReadOnly="True" Header="{DynamicResource OperationsView_UsageDate}" Binding="{Binding UsageDate}"/>
-                    <DataGridTextColumn IsReadOnly="True" Header="{DynamicResource OperationsView_UnitPrice}" Binding="{Binding Material.PricePerUnit}"/>
+                    <DataGridTextColumn IsReadOnly="True" Header="{DynamicResource OperationsView_UnitPrice}" Binding="{Binding DisplayUnitPrice}"/>
                     <DataGridTemplateColumn Header="{DynamicResource OperationsView_Total}" Width="120" IsReadOnly="True">
                         <DataGridTemplateColumn.CellTemplate>
                             <DataTemplate>
@@ -400,7 +400,7 @@
                                     <TextBlock.Text>
                                         <MultiBinding Converter="{StaticResource TotalCostConverter}" StringFormat="{}{0:0.##}">
                                             <Binding Path="Qty"/>
-                                            <Binding Path="Material.PricePerUnit"/>
+                                            <Binding Path="DisplayUnitPrice"/>
                                         </MultiBinding>
                                     </TextBlock.Text>
                                 </TextBlock>


### PR DESCRIPTION
## Summary
- add a not-mapped display price on material usages so the UI can show a computed unit price
- load material usages with price history, display the effective price at the usage date for finished sub-stages, and refresh the list through a shared helper
- set each usage's date when finishing a sub-stage so the frozen price aligns with the completion date

## Testing
- `dotnet build Kanstraction/Kanstraction.csproj` *(fails: `dotnet` command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d26a81f0ec832dbf8090baf6e360b2