### PR TITLE
Add delete operations for stage hierarchy in operations view

### DIFF
--- a/Kanstraction/Resources/StringResources.fr.xaml
+++ b/Kanstraction/Resources/StringResources.fr.xaml
@@ -161,11 +161,13 @@
     <sys:String x:Key="OperationsView_Stage">Étape</sys:String>
     <sys:String x:Key="OperationsView_OngoingSubStage">Sous-étape en cours</sys:String>
     <sys:String x:Key="OperationsView_AddSubStageTooltip">Ajouter une sous-étape à l'étape sélectionnée</sys:String>
+    <sys:String x:Key="OperationsView_DeleteStageTooltip">Supprimer cette étape du bâtiment</sys:String>
     <sys:String x:Key="OperationsView_Name">Nom</sys:String>
     <sys:String x:Key="OperationsView_Labor">Main-d'œuvre</sys:String>
     <sys:String x:Key="OperationsView_StartSubStageTooltip">Commencer la sous-étape</sys:String>
     <sys:String x:Key="OperationsView_FinishSubStageTooltip">Terminer la sous-étape</sys:String>
     <sys:String x:Key="OperationsView_ResetSubStageTooltip">Marquer comme non commencé</sys:String>
+    <sys:String x:Key="OperationsView_DeleteSubStageTooltip">Supprimer cette sous-étape de l'étape</sys:String>
     <sys:String x:Key="OperationsView_Stages">Étapes</sys:String>
     <sys:String x:Key="OperationsView_SubStages">Sous-étapes</sys:String>
     <sys:String x:Key="OperationsView_MaterialHeader">Matériau</sys:String>
@@ -174,6 +176,7 @@
     <sys:String x:Key="OperationsView_UsageDate">Date d'utilisation</sys:String>
     <sys:String x:Key="OperationsView_UnitPrice">Prix unitaire</sys:String>
     <sys:String x:Key="OperationsView_Total">Total</sys:String>
+    <sys:String x:Key="OperationsView_DeleteMaterialTooltip">Supprimer ce matériau de la sous-étape</sys:String>
     <sys:String x:Key="OperationsView_ConfirmChangeTitle">Enregistrer</sys:String>
     <sys:String x:Key="OperationsView_ReturnToDefault">Annuler</sys:String>
     <sys:String x:Key="OperationsView_ConfirmLaborChangeMessage">Êtes-vous sûr de vouloir changer la main-d'œuvre de {0} à {1} ?</sys:String>
@@ -197,6 +200,15 @@
     <sys:String x:Key="OperationsView_SubStageCannotStart">Cette sous-étape ne peut pas être démarrée dans son état actuel.</sys:String>
     <sys:String x:Key="OperationsView_OnlyOngoingCanFinish">Vous ne pouvez terminer qu'une sous-étape En cours.</sys:String>
     <sys:String x:Key="OperationsView_OnlyOngoingCanReset">Seule une sous-étape En cours peut être réinitialisée à Non commencée.</sys:String>
+    <sys:String x:Key="OperationsView_DeleteStageTitle">Supprimer l'étape</sys:String>
+    <sys:String x:Key="OperationsView_DeleteStageConfirmFormat">Supprimer l'étape « {0} » ? Toutes ses sous-étapes et matériaux seront supprimés.</sys:String>
+    <sys:String x:Key="OperationsView_DeleteStageFailedFormat">Impossible de supprimer l'étape :&#x0a;{0}</sys:String>
+    <sys:String x:Key="OperationsView_DeleteSubStageTitle">Supprimer la sous-étape</sys:String>
+    <sys:String x:Key="OperationsView_DeleteSubStageConfirmFormat">Supprimer la sous-étape « {0} » ? Les matériaux associés seront supprimés.</sys:String>
+    <sys:String x:Key="OperationsView_DeleteSubStageFailedFormat">Impossible de supprimer la sous-étape :&#x0a;{0}</sys:String>
+    <sys:String x:Key="OperationsView_DeleteMaterialTitle">Supprimer le matériau</sys:String>
+    <sys:String x:Key="OperationsView_DeleteMaterialConfirmFormat">Supprimer le matériau « {0} » de cette sous-étape ?</sys:String>
+    <sys:String x:Key="OperationsView_DeleteMaterialFailedFormat">Impossible de supprimer le matériau :&#x0a;{0}</sys:String>
     <sys:String x:Key="OperationsView_SelectSubStageFirst">Sélectionnez d'abord une sous-étape.</sys:String>
     <sys:String x:Key="OperationsView_NoSubStageTitle">Aucune sous-étape</sys:String>
     <sys:String x:Key="OperationsView_SelectMaterialPrompt">Veuillez sélectionner un matériau.</sys:String>

--- a/Kanstraction/Resources/StringResources.xaml
+++ b/Kanstraction/Resources/StringResources.xaml
@@ -163,11 +163,13 @@
     <sys:String x:Key="OperationsView_Stage">Stage</sys:String>
     <sys:String x:Key="OperationsView_OngoingSubStage">Ongoing Sub-stage</sys:String>
     <sys:String x:Key="OperationsView_AddSubStageTooltip">Add sub-stage to selected stage</sys:String>
+    <sys:String x:Key="OperationsView_DeleteStageTooltip">Remove this stage from the building</sys:String>
     <sys:String x:Key="OperationsView_Name">Name</sys:String>
     <sys:String x:Key="OperationsView_Labor">Labor</sys:String>
     <sys:String x:Key="OperationsView_StartSubStageTooltip">Start sub-stage</sys:String>
     <sys:String x:Key="OperationsView_FinishSubStageTooltip">Finish sub-stage</sys:String>
     <sys:String x:Key="OperationsView_ResetSubStageTooltip">Mark as Not Started</sys:String>
+    <sys:String x:Key="OperationsView_DeleteSubStageTooltip">Remove this sub-stage from the stage</sys:String>
     <sys:String x:Key="OperationsView_Stages">Stages</sys:String>
     <sys:String x:Key="OperationsView_SubStages">Sub-stages</sys:String>
     <sys:String x:Key="OperationsView_MaterialHeader">Material</sys:String>
@@ -176,6 +178,7 @@
     <sys:String x:Key="OperationsView_UsageDate">Usage Date</sys:String>
     <sys:String x:Key="OperationsView_UnitPrice">Unit Price</sys:String>
     <sys:String x:Key="OperationsView_Total">Total</sys:String>
+    <sys:String x:Key="OperationsView_DeleteMaterialTooltip">Remove this material from the sub-stage</sys:String>
     <sys:String x:Key="OperationsView_ConfirmChangeTitle">Save</sys:String>
     <sys:String x:Key="OperationsView_ReturnToDefault">Cancel</sys:String>
     <sys:String x:Key="OperationsView_ConfirmLaborChangeMessage">Are you sure you want to change the labor from {0} to {1}?</sys:String>
@@ -198,6 +201,15 @@
     <sys:String x:Key="OperationsView_PreviousStagesRequired">You must finish all previous stages before starting this stage.</sys:String>
     <sys:String x:Key="OperationsView_SubStageCannotStart">This sub-stage cannot be started in its current state.</sys:String>
     <sys:String x:Key="OperationsView_OnlyOngoingCanFinish">You can only finish an Ongoing sub-stage.</sys:String>
+    <sys:String x:Key="OperationsView_DeleteStageTitle">Delete stage</sys:String>
+    <sys:String x:Key="OperationsView_DeleteStageConfirmFormat">Delete stage '{0}'? All of its sub-stages and materials will be removed.</sys:String>
+    <sys:String x:Key="OperationsView_DeleteStageFailedFormat">Failed to delete stage:&#x0a;{0}</sys:String>
+    <sys:String x:Key="OperationsView_DeleteSubStageTitle">Delete sub-stage</sys:String>
+    <sys:String x:Key="OperationsView_DeleteSubStageConfirmFormat">Delete sub-stage '{0}'? Materials assigned to it will be removed.</sys:String>
+    <sys:String x:Key="OperationsView_DeleteSubStageFailedFormat">Failed to delete sub-stage:&#x0a;{0}</sys:String>
+    <sys:String x:Key="OperationsView_DeleteMaterialTitle">Delete material</sys:String>
+    <sys:String x:Key="OperationsView_DeleteMaterialConfirmFormat">Delete material '{0}' from this sub-stage?</sys:String>
+    <sys:String x:Key="OperationsView_DeleteMaterialFailedFormat">Failed to delete material:&#x0a;{0}</sys:String>
     <sys:String x:Key="OperationsView_OnlyOngoingCanReset">Only an Ongoing sub-stage can be reset to Not Started.</sys:String>
     <sys:String x:Key="OperationsView_SelectSubStageFirst">Select a sub-stage first.</sys:String>
     <sys:String x:Key="OperationsView_NoSubStageTitle">No sub-stage</sys:String>

--- a/Kanstraction/Views/OperationsView.xaml
+++ b/Kanstraction/Views/OperationsView.xaml
@@ -210,6 +210,18 @@
                     </DataGridTemplateColumn>
                     <DataGridTextColumn Header="{DynamicResource OperationsView_OngoingSubStage}" Binding="{Binding OngoingSubStageName}"/>
                     <DataGridTextColumn Header="{DynamicResource OperationsView_Percent}" Binding="{Binding ProgressPercent}"/>
+                    <DataGridTemplateColumn Header="" Width="60">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Button Style="{StaticResource TinyIconButton}"
+                                        Tag="{Binding Id}"
+                                        Click="DeleteStage_Click"
+                                        ToolTip="{DynamicResource OperationsView_DeleteStageTooltip}">
+                                    <iconPacks:PackIconFontAwesome Kind="TrashCanRegular" Width="12" Height="12" Foreground="Red"/>
+                                </Button>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
         </Grid>
@@ -336,6 +348,18 @@
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>
+                    <DataGridTemplateColumn Header="" Width="60">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Button Style="{StaticResource TinyIconButton}"
+                                        Tag="{Binding Id}"
+                                        Click="DeleteSubStageInstance_Click"
+                                        ToolTip="{DynamicResource OperationsView_DeleteSubStageTooltip}">
+                                    <iconPacks:PackIconFontAwesome Kind="TrashCanRegular" Width="12" Height="12" Foreground="Red"/>
+                                </Button>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
                 </DataGrid.Columns>
             </DataGrid>
         </Grid>
@@ -404,6 +428,18 @@
                                         </MultiBinding>
                                     </TextBlock.Text>
                                 </TextBlock>
+                            </DataTemplate>
+                        </DataGridTemplateColumn.CellTemplate>
+                    </DataGridTemplateColumn>
+                    <DataGridTemplateColumn Header="" Width="60">
+                        <DataGridTemplateColumn.CellTemplate>
+                            <DataTemplate>
+                                <Button Style="{StaticResource TinyIconButton}"
+                                        Tag="{Binding Id}"
+                                        Click="DeleteMaterialUsage_Click"
+                                        ToolTip="{DynamicResource OperationsView_DeleteMaterialTooltip}">
+                                    <iconPacks:PackIconFontAwesome Kind="TrashCanRegular" Width="12" Height="12" Foreground="Red"/>
+                                </Button>
                             </DataTemplate>
                         </DataGridTemplateColumn.CellTemplate>
                     </DataGridTemplateColumn>

--- a/Kanstraction/Views/OperationsView.xaml.cs
+++ b/Kanstraction/Views/OperationsView.xaml.cs
@@ -1074,9 +1074,20 @@ public partial class OperationsView : UserControl
         }
     }
 
-    private static void UpdateStageStatusFromSubStages(Stage s)
+    private static void UpdateStageStatusFromSubStages(Stage? s)
     {
-        if (s.SubStages == null || s.SubStages.Count == 0) return;
+        if (s == null)
+        {
+            return;
+        }
+
+        if (s.SubStages == null || s.SubStages.Count == 0)
+        {
+            s.Status = WorkStatus.NotStarted;
+            s.StartDate = null;
+            s.EndDate = null;
+            return;
+        }
 
         bool allPaid = s.SubStages.All(ss => ss.Status == WorkStatus.Paid);
         bool anyOngoing = s.SubStages.Any(ss => ss.Status == WorkStatus.Ongoing);


### PR DESCRIPTION
## Summary
- add delete buttons for stages, sub-stages, and materials in the Operations view
- implement handlers that remove items, reorder remaining entries, and refresh the UI
- provide localized strings for the new tooltips and confirmation dialogs

## Testing
- `dotnet build` *(fails: command not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e530a28a88832da72bb37ea3f4c8db