### PR TITLE
Add material categories support and expose them in UI

### DIFF
--- a/Kanstraction/Data/AppDbContext.cs
+++ b/Kanstraction/Data/AppDbContext.cs
@@ -16,6 +16,7 @@ public class AppDbContext : DbContext
     public DbSet<SubStagePreset> SubStagePresets => Set<SubStagePreset>();
     public DbSet<BuildingTypeStagePreset> BuildingTypeStagePresets => Set<BuildingTypeStagePreset>();
     public DbSet<BuildingTypeSubStageLabor> BuildingTypeSubStageLabors => Set<BuildingTypeSubStageLabor>();
+    public DbSet<MaterialCategory> MaterialCategories => Set<MaterialCategory>();
     public DbSet<Material> Materials => Set<Material>();
     public DbSet<MaterialPriceHistory> MaterialPriceHistory => Set<MaterialPriceHistory>();
     public DbSet<MaterialUsagePreset> MaterialUsagesPreset => Set<MaterialUsagePreset>();
@@ -85,6 +86,12 @@ public class AppDbContext : DbContext
             .HasOne(x => x.Material).WithMany(m => m.PriceHistory)
             .HasForeignKey(x => x.MaterialId).OnDelete(DeleteBehavior.Cascade);
 
+        b.Entity<Material>()
+            .HasOne(m => m.MaterialCategory)
+            .WithMany(c => c.Materials)
+            .HasForeignKey(m => m.MaterialCategoryId)
+            .OnDelete(DeleteBehavior.Restrict);
+
         b.Entity<MaterialUsage>()
             .HasOne(x => x.SubStage).WithMany(ss => ss.MaterialUsages)
             .HasForeignKey(x => x.SubStageId).OnDelete(DeleteBehavior.Cascade);
@@ -92,6 +99,8 @@ public class AppDbContext : DbContext
             .HasOne(x => x.Material).WithMany().HasForeignKey(x => x.MaterialId);
 
         // indexes
+        b.Entity<MaterialCategory>().HasIndex(x => x.Name).IsUnique();
+        b.Entity<Material>().HasIndex(x => x.MaterialCategoryId);
         b.Entity<Stage>().HasIndex(x => new { x.BuildingId, x.OrderIndex });
         b.Entity<SubStage>().HasIndex(x => new { x.StageId, x.OrderIndex });
         b.Entity<MaterialUsage>().HasIndex(x => new { x.SubStageId, x.UsageDate });

--- a/Kanstraction/Data/DbSeeder.cs
+++ b/Kanstraction/Data/DbSeeder.cs
@@ -15,6 +15,8 @@ namespace Kanstraction.Data
     /// </summary>
     public static class DbSeeder
     {
+        private const string DefaultCategoryName = "Defaut";
+
         public static void Seed(AppDbContext db)
         {
             // No early return: let each Ensure* handle its own idempotency
@@ -26,18 +28,20 @@ namespace Kanstraction.Data
         // ---------------- MATERIALS ----------------
         private static Dictionary<string, Material> EnsureMaterials(AppDbContext db)
         {
+            var defaultCategory = EnsureDefaultMaterialCategory(db);
+
             // Target materials (French set — keep consistent names)
             var wanted = new[]
             {
-                new Material { Name = "Ciment",   Unit = "sac", PricePerUnit =  6.50m, EffectiveSince = DateTime.Today.AddMonths(-4), IsActive = true },
-                new Material { Name = "Sable",    Unit = "m³",  PricePerUnit = 12.00m, EffectiveSince = DateTime.Today.AddMonths(-3), IsActive = true },
-                new Material { Name = "Gravier",  Unit = "m³",  PricePerUnit = 15.00m, EffectiveSince = DateTime.Today.AddMonths(-3), IsActive = true },
-                new Material { Name = "Armature", Unit = "kg",  PricePerUnit =  1.20m, EffectiveSince = DateTime.Today.AddMonths(-5), IsActive = true },
-                new Material { Name = "Blocs",    Unit = "pcs", PricePerUnit =  0.90m, EffectiveSince = DateTime.Today.AddMonths(-2), IsActive = true },
-                new Material { Name = "Peinture", Unit = "gal", PricePerUnit = 18.00m, EffectiveSince = DateTime.Today.AddMonths(-1), IsActive = true },
-                new Material { Name = "Câblage",  Unit = "m",   PricePerUnit =  0.35m, EffectiveSince = DateTime.Today.AddMonths(-6), IsActive = true },
-                new Material { Name = "Tuyaux",   Unit = "m",   PricePerUnit =  0.80m, EffectiveSince = DateTime.Today.AddMonths(-6), IsActive = true },
-                new Material { Name = "Plâtre",   Unit = "sac", PricePerUnit =  7.20m, EffectiveSince = DateTime.Today.AddMonths(-2), IsActive = true },
+                new Material { Name = "Ciment",   Unit = "sac", PricePerUnit =  6.50m, EffectiveSince = DateTime.Today.AddMonths(-4), IsActive = true, MaterialCategoryId = defaultCategory.Id },
+                new Material { Name = "Sable",    Unit = "m³",  PricePerUnit = 12.00m, EffectiveSince = DateTime.Today.AddMonths(-3), IsActive = true, MaterialCategoryId = defaultCategory.Id },
+                new Material { Name = "Gravier",  Unit = "m³",  PricePerUnit = 15.00m, EffectiveSince = DateTime.Today.AddMonths(-3), IsActive = true, MaterialCategoryId = defaultCategory.Id },
+                new Material { Name = "Armature", Unit = "kg",  PricePerUnit =  1.20m, EffectiveSince = DateTime.Today.AddMonths(-5), IsActive = true, MaterialCategoryId = defaultCategory.Id },
+                new Material { Name = "Blocs",    Unit = "pcs", PricePerUnit =  0.90m, EffectiveSince = DateTime.Today.AddMonths(-2), IsActive = true, MaterialCategoryId = defaultCategory.Id },
+                new Material { Name = "Peinture", Unit = "gal", PricePerUnit = 18.00m, EffectiveSince = DateTime.Today.AddMonths(-1), IsActive = true, MaterialCategoryId = defaultCategory.Id },
+                new Material { Name = "Câblage",  Unit = "m",   PricePerUnit =  0.35m, EffectiveSince = DateTime.Today.AddMonths(-6), IsActive = true, MaterialCategoryId = defaultCategory.Id },
+                new Material { Name = "Tuyaux",   Unit = "m",   PricePerUnit =  0.80m, EffectiveSince = DateTime.Today.AddMonths(-6), IsActive = true, MaterialCategoryId = defaultCategory.Id },
+                new Material { Name = "Plâtre",   Unit = "sac", PricePerUnit =  7.20m, EffectiveSince = DateTime.Today.AddMonths(-2), IsActive = true, MaterialCategoryId = defaultCategory.Id },
             };
 
             // Upsert materials by (case-insensitive) name
@@ -102,6 +106,25 @@ namespace Kanstraction.Data
             }
 
             return byName;
+        }
+
+        private static MaterialCategory EnsureDefaultMaterialCategory(AppDbContext db)
+        {
+            var existing = db.MaterialCategories.FirstOrDefault(c => c.Name == DefaultCategoryName);
+            if (existing != null)
+            {
+                return existing;
+            }
+
+            var category = new MaterialCategory
+            {
+                Name = DefaultCategoryName
+            };
+
+            db.MaterialCategories.Add(category);
+            db.SaveChanges();
+
+            return category;
         }
 
         // ---------------- STAGE PRESETS (+ SUBS + MATERIAL USAGES) ----------------

--- a/Kanstraction/Entities/Material.cs
+++ b/Kanstraction/Entities/Material.cs
@@ -8,6 +8,9 @@ public class Material
     public decimal PricePerUnit { get; set; }
     public DateTime EffectiveSince { get; set; }
     public bool IsActive { get; set; } = true;
+    public int MaterialCategoryId { get; set; }
+
+    public MaterialCategory MaterialCategory { get; set; } = null!;
 
     public ICollection<MaterialPriceHistory> PriceHistory { get; set; } = new List<MaterialPriceHistory>();
 }

--- a/Kanstraction/Entities/MaterialCategory.cs
+++ b/Kanstraction/Entities/MaterialCategory.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace Kanstraction.Entities;
+
+public class MaterialCategory
+{
+    public int Id { get; set; }
+    public string Name { get; set; } = string.Empty;
+
+    public ICollection<Material> Materials { get; set; } = new List<Material>();
+}

--- a/Kanstraction/Migrations/20250924170000_AddMaterialCategories.Designer.cs
+++ b/Kanstraction/Migrations/20250924170000_AddMaterialCategories.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Kanstraction.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace Kanstraction.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250924170000_AddMaterialCategories")]
+    partial class AddMaterialCategories
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.8");

--- a/Kanstraction/Migrations/20250924170000_AddMaterialCategories.cs
+++ b/Kanstraction/Migrations/20250924170000_AddMaterialCategories.cs
@@ -1,0 +1,77 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Kanstraction.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMaterialCategories : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "MaterialCategories",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Name = table.Column<string>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_MaterialCategories", x => x.Id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_MaterialCategories_Name",
+                table: "MaterialCategories",
+                column: "Name",
+                unique: true);
+
+            migrationBuilder.InsertData(
+                table: "MaterialCategories",
+                columns: new[] { "Id", "Name" },
+                values: new object[] { 1, "Defaut" });
+
+            migrationBuilder.AddColumn<int>(
+                name: "MaterialCategoryId",
+                table: "Materials",
+                type: "INTEGER",
+                nullable: false,
+                defaultValue: 1);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Materials_MaterialCategoryId",
+                table: "Materials",
+                column: "MaterialCategoryId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Materials_MaterialCategories_MaterialCategoryId",
+                table: "Materials",
+                column: "MaterialCategoryId",
+                principalTable: "MaterialCategories",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Materials_MaterialCategories_MaterialCategoryId",
+                table: "Materials");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Materials_MaterialCategoryId",
+                table: "Materials");
+
+            migrationBuilder.DropColumn(
+                name: "MaterialCategoryId",
+                table: "Materials");
+
+            migrationBuilder.DropTable(
+                name: "MaterialCategories");
+        }
+    }
+}

--- a/Kanstraction/Resources/StringResources.fr.xaml
+++ b/Kanstraction/Resources/StringResources.fr.xaml
@@ -72,6 +72,7 @@
     <sys:String x:Key="AdminHubView_New">Nouveau</sys:String>
     <sys:String x:Key="AdminHubView_MaterialHeader">Matériau</sys:String>
     <sys:String x:Key="AdminHubView_Name">Nom</sys:String>
+    <sys:String x:Key="AdminHubView_Category">Catégorie</sys:String>
     <sys:String x:Key="AdminHubView_Unit">Unité</sys:String>
     <sys:String x:Key="AdminHubView_PricePerUnit">Prix / Unité</sys:String>
     <sys:String x:Key="AdminHubView_Active">Actif</sys:String>
@@ -110,6 +111,12 @@
     <sys:String x:Key="AdminHubView_BuildingTypeNameRequired">Le nom est requis.</sys:String>
     <sys:String x:Key="AdminHubView_BuildingTypeSavedMessage">Type de bâtiment enregistré.</sys:String>
     <sys:String x:Key="AdminHubView_SaveBuildingTypeFailedFormat">Échec de l'enregistrement :&#x0a;{0}</sys:String>
+    <sys:String x:Key="AdminHubView_FilterByCategory">Filtrer par catégorie</sys:String>
+    <sys:String x:Key="AdminHubView_AddCategoryTooltip">Ajouter une catégorie</sys:String>
+    <sys:String x:Key="AdminHubView_NewCategoryDialogTitle">Nouvelle catégorie</sys:String>
+    <sys:String x:Key="AdminHubView_CategoryExistsMessage">Une catégorie portant ce nom existe déjà.</sys:String>
+    <sys:String x:Key="AdminHubView_CategoryRequired">La catégorie est obligatoire.</sys:String>
+    <sys:String x:Key="AdminHubView_CategoryFilterAll">Toutes les catégories</sys:String>
 
     <!-- BackupHubView -->
     <sys:String x:Key="BackupHubView_Title">Sauvegardes et restauration</sys:String>
@@ -171,6 +178,7 @@
     <sys:String x:Key="OperationsView_Stages">Étapes</sys:String>
     <sys:String x:Key="OperationsView_SubStages">Sous-étapes</sys:String>
     <sys:String x:Key="OperationsView_MaterialHeader">Matériau</sys:String>
+    <sys:String x:Key="OperationsView_Category">Catégorie</sys:String>
     <sys:String x:Key="OperationsView_Qty">Qté</sys:String>
     <sys:String x:Key="OperationsView_Unit">Unité</sys:String>
     <sys:String x:Key="OperationsView_UsageDate">Date d'utilisation</sys:String>
@@ -237,6 +245,7 @@
     <sys:String x:Key="StagePresetDesignerView_Labor">Main-d'œuvre</sys:String>
     <sys:String x:Key="StagePresetDesignerView_AddSubStage">Ajouter une sous-étape</sys:String>
     <sys:String x:Key="StagePresetDesignerView_MaterialsForSelected">Matériaux pour la sous-étape sélectionnée</sys:String>
+    <sys:String x:Key="StagePresetDesignerView_Category">Catégorie</sys:String>
     <sys:String x:Key="StagePresetDesignerView_NewSubStage">Nouvelle sous-étape</sys:String>
     <sys:String x:Key="StagePresetDesignerView_PresetNotFound">Préréglage introuvable.</sys:String>
     <sys:String x:Key="StagePresetDesignerView_DeleteSubStageConfirmFormat">Supprimer la sous-étape '{0}' ?</sys:String>

--- a/Kanstraction/Resources/StringResources.xaml
+++ b/Kanstraction/Resources/StringResources.xaml
@@ -72,6 +72,7 @@
     <sys:String x:Key="AdminHubView_New">New</sys:String>
     <sys:String x:Key="AdminHubView_MaterialHeader">Material</sys:String>
     <sys:String x:Key="AdminHubView_Name">Name</sys:String>
+    <sys:String x:Key="AdminHubView_Category">Category</sys:String>
     <sys:String x:Key="AdminHubView_Unit">Unit</sys:String>
     <sys:String x:Key="AdminHubView_PricePerUnit">Price / Unit</sys:String>
     <sys:String x:Key="AdminHubView_Active">Active</sys:String>
@@ -112,6 +113,12 @@
     <sys:String x:Key="AdminHubView_BuildingTypeNameRequired">Name is required.</sys:String>
     <sys:String x:Key="AdminHubView_BuildingTypeSavedMessage">Building type saved.</sys:String>
     <sys:String x:Key="AdminHubView_SaveBuildingTypeFailedFormat">Saving failed:&#x0a;{0}</sys:String>
+    <sys:String x:Key="AdminHubView_FilterByCategory">Filter by category</sys:String>
+    <sys:String x:Key="AdminHubView_AddCategoryTooltip">Add category</sys:String>
+    <sys:String x:Key="AdminHubView_NewCategoryDialogTitle">New category</sys:String>
+    <sys:String x:Key="AdminHubView_CategoryExistsMessage">A category with this name already exists.</sys:String>
+    <sys:String x:Key="AdminHubView_CategoryRequired">Category is required.</sys:String>
+    <sys:String x:Key="AdminHubView_CategoryFilterAll">All categories</sys:String>
 
     <!-- BackupHubView -->
     <sys:String x:Key="BackupHubView_Title">Backups &amp; Restore</sys:String>
@@ -173,6 +180,7 @@
     <sys:String x:Key="OperationsView_Stages">Stages</sys:String>
     <sys:String x:Key="OperationsView_SubStages">Sub-stages</sys:String>
     <sys:String x:Key="OperationsView_MaterialHeader">Material</sys:String>
+    <sys:String x:Key="OperationsView_Category">Category</sys:String>
     <sys:String x:Key="OperationsView_Qty">Qty</sys:String>
     <sys:String x:Key="OperationsView_Unit">Unit</sys:String>
     <sys:String x:Key="OperationsView_UsageDate">Usage Date</sys:String>
@@ -239,6 +247,7 @@
     <sys:String x:Key="StagePresetDesignerView_Labor">Labor</sys:String>
     <sys:String x:Key="StagePresetDesignerView_AddSubStage">Add Sub-stage</sys:String>
     <sys:String x:Key="StagePresetDesignerView_MaterialsForSelected">Materials for selected sub-stage</sys:String>
+    <sys:String x:Key="StagePresetDesignerView_Category">Category</sys:String>
     <sys:String x:Key="StagePresetDesignerView_NewSubStage">New sub-stage</sys:String>
     <sys:String x:Key="StagePresetDesignerView_PresetNotFound">Preset not found.</sys:String>
     <sys:String x:Key="StagePresetDesignerView_DeleteSubStageConfirmFormat">Delete sub-stage '{0}'?</sys:String>

--- a/Kanstraction/ViewModels/StagePresetDesignerView.xaml
+++ b/Kanstraction/ViewModels/StagePresetDesignerView.xaml
@@ -162,7 +162,23 @@
                                 <!-- Add material row -->
                                 <StackPanel Grid.Row="1" Orientation="Horizontal" Margin="0,0,0,8">
                                     <ComboBox x:Name="CboMaterial" Width="280" Margin="0,0,8,0"
-                          DisplayMemberPath="Name" SelectedValuePath="Id" SelectionChanged="MaterialSelected"/>
+                                              SelectedValuePath="Id"
+                                              IsEditable="True"
+                                              IsTextSearchEnabled="True"
+                                              StaysOpenOnEdit="True"
+                                              TextSearch.TextPath="Name"
+                                              SelectionChanged="MaterialSelected">
+                                        <ComboBox.ItemTemplate>
+                                            <DataTemplate>
+                                                <StackPanel>
+                                                    <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
+                                                    <TextBlock Text="{Binding MaterialCategory.Name}"
+                                                               FontSize="12"
+                                                               Foreground="{DynamicResource MaterialDesignBodyLight}"/>
+                                                </StackPanel>
+                                            </DataTemplate>
+                                        </ComboBox.ItemTemplate>
+                                    </ComboBox>
                                     <TextBox x:Name="TxtQty" Width="120" Margin="0,0,8,0"
                          materialDesign:HintAssist.Hint="{DynamicResource AddMaterialToSubStageDialog_QuantityHint}" />
                                     <TextBlock x:Name="TxtMTUnit" Width="30" Margin="8,0,8,0" VerticalAlignment="Center" FontWeight="Bold"/>
@@ -175,6 +191,7 @@
                         Style="{StaticResource MaterialDesignDataGrid}">
                                     <DataGrid.Columns>
                                         <DataGridTextColumn Header="{DynamicResource OperationsView_MaterialHeader}" Binding="{Binding MaterialName}" IsReadOnly="True" Width="*"/>
+                                        <DataGridTextColumn Header="{DynamicResource StagePresetDesignerView_Category}" Binding="{Binding CategoryName}" IsReadOnly="True" Width="160"/>
                                         <DataGridTextColumn Header="{DynamicResource AdminHubView_Unit}" Binding="{Binding Unit}" IsReadOnly="True" Width="80"/>
                                         <DataGridTextColumn Header="{DynamicResource OperationsView_Qty}" Binding="{Binding Qty, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.##}}" Width="120"/>
                                         <DataGridTemplateColumn Header="" Width="80">

--- a/Kanstraction/ViewModels/StagePresetDesignerView.xaml.cs
+++ b/Kanstraction/ViewModels/StagePresetDesignerView.xaml.cs
@@ -120,7 +120,9 @@ public partial class StagePresetDesignerView : UserControl
         // Load active materials (for picker)
         _activeMaterials = await _db.Materials.AsNoTracking()
                                .Where(m => m.IsActive)
-                               .OrderBy(m => m.Name)
+                               .Include(m => m.MaterialCategory)
+                               .OrderBy(m => m.MaterialCategory != null ? m.MaterialCategory.Name : string.Empty)
+                               .ThenBy(m => m.Name)
                                .ToListAsync();
 
         if (stagePresetId == null)
@@ -128,7 +130,9 @@ public partial class StagePresetDesignerView : UserControl
             // load active materials
             _activeMaterials = await _db.Materials.AsNoTracking()
                 .Where(m => m.IsActive)
-                .OrderBy(m => m.Name)
+                .Include(m => m.MaterialCategory)
+                .OrderBy(m => m.MaterialCategory != null ? m.MaterialCategory.Name : string.Empty)
+                .ThenBy(m => m.Name)
                 .ToListAsync();
 
             TxtPresetName.Text = "";
@@ -169,6 +173,7 @@ public partial class StagePresetDesignerView : UserControl
         var usageLookup = await _db.MaterialUsagesPreset
             .Where(mu => subIds.Contains(mu.SubStagePresetId))
             .Include(mu => mu.Material)
+                .ThenInclude(m => m.MaterialCategory)
             .AsNoTracking()
             .ToListAsync();
 
@@ -190,6 +195,7 @@ public partial class StagePresetDesignerView : UserControl
                     Id = mu.Id,
                     MaterialId = mu.MaterialId,
                     MaterialName = mu.Material?.Name ?? "",
+                    CategoryName = mu.Material?.MaterialCategory?.Name ?? "",
                     Unit = mu.Material?.Unit ?? "",
                     Qty = mu.Qty
                 });
@@ -440,6 +446,7 @@ public partial class StagePresetDesignerView : UserControl
             Id = null,
             MaterialId = mat.Id,
             MaterialName = mat.Name,
+            CategoryName = mat.MaterialCategory?.Name ?? "",
             Unit = mat.Unit ?? "",
             Qty = qty
         });
@@ -828,6 +835,7 @@ public partial class StagePresetDesignerView : UserControl
         public int? Id { get; set; }
         public int MaterialId { get; set; }
         public string MaterialName { get; set; } = "";
+        public string CategoryName { get; set; } = "";
         public string Unit { get; set; } = "";
         public decimal Qty { get; set; }
     }

--- a/Kanstraction/Views/AddMaterialToSubStageDialog.xaml
+++ b/Kanstraction/Views/AddMaterialToSubStageDialog.xaml
@@ -22,9 +22,22 @@
                 <TextBlock Text="{DynamicResource AddMaterialToSubStageDialog_Material}" Width="110" VerticalAlignment="Center"/>
                 <ComboBox x:Name="CboMaterial"
                   Style="{StaticResource MaterialDesignOutlinedComboBox}"
-                  DisplayMemberPath="Name" SelectedValuePath="Id"
+                  SelectedValuePath="Id"
+                  IsEditable="True"
+                  IsTextSearchEnabled="True"
+                  StaysOpenOnEdit="True"
+                  TextSearch.TextPath="Name"
                   Padding="6" FontSize="14" Width="320"
-                  SelectionChanged="CboMaterial_SelectionChanged"/>
+                  SelectionChanged="CboMaterial_SelectionChanged">
+                    <ComboBox.ItemTemplate>
+                        <DataTemplate>
+                            <StackPanel>
+                                <TextBlock Text="{Binding Name}" FontWeight="SemiBold"/>
+                                <TextBlock Text="{Binding MaterialCategory.Name}" FontSize="12" Foreground="{DynamicResource MaterialDesignBodyLight}"/>
+                            </StackPanel>
+                        </DataTemplate>
+                    </ComboBox.ItemTemplate>
+                </ComboBox>
             </DockPanel>
 
             <DockPanel>

--- a/Kanstraction/Views/AddMaterialToSubStageDialog.xaml.cs
+++ b/Kanstraction/Views/AddMaterialToSubStageDialog.xaml.cs
@@ -40,8 +40,10 @@ public partial class AddMaterialToSubStageDialog : Window
 
         var materials = await _db.Materials
             .AsNoTracking()
+            .Include(m => m.MaterialCategory)
             .Where(m => m.IsActive && !usedIds.Contains(m.Id))
-            .OrderBy(m => m.Name)
+            .OrderBy(m => m.MaterialCategory != null ? m.MaterialCategory.Name : string.Empty)
+            .ThenBy(m => m.Name)
             .ToListAsync();
 
         CboMaterial.ItemsSource = materials;

--- a/Kanstraction/Views/AdminHubView.xaml
+++ b/Kanstraction/Views/AdminHubView.xaml
@@ -50,6 +50,17 @@
                             <CheckBox x:Name="MatActiveOnly"
                         Content="{DynamicResource AdminHubView_ActiveOnly}" Margin="0,8,0,0"
                         IsChecked="True" Checked="MatFilterChanged" Unchecked="MatFilterChanged"/>
+                            <ComboBox x:Name="MatCategoryFilter"
+                                      Margin="0,8,0,0"
+                                      Style="{StaticResource MaterialDesignOutlinedComboBox}"
+                                      materialDesign:HintAssist.Hint="{DynamicResource AdminHubView_FilterByCategory}"
+                                      IsEditable="True"
+                                      IsTextSearchEnabled="True"
+                                      StaysOpenOnEdit="True"
+                                      TextSearch.TextPath="Name"
+                                      DisplayMemberPath="Name"
+                                      SelectedValuePath="Id"
+                                      SelectionChanged="MatFilterChanged" />
                         </StackPanel>
 
                         <ListView x:Name="MaterialsList" Grid.Row="1" Margin="10"
@@ -86,6 +97,38 @@
                                 <DockPanel Margin="0,0,0,8">
                                     <TextBlock Text="{DynamicResource AdminHubView_Name}" Width="120" VerticalAlignment="Center"/>
                                     <TextBox x:Name="MatName" Padding="8" TextChanged="MaterialEditor_TextChanged" />
+                                </DockPanel>
+                                <DockPanel Margin="0,0,0,8">
+                                    <TextBlock Text="{DynamicResource AdminHubView_Category}" Width="120" VerticalAlignment="Center"/>
+                                    <Grid Margin="0">
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="*"/>
+                                            <ColumnDefinition Width="Auto"/>
+                                        </Grid.ColumnDefinitions>
+                                        <ComboBox x:Name="MatCategory"
+                                                  Grid.Column="0"
+                                                  MinWidth="220"
+                                                  Padding="8"
+                                                  Style="{StaticResource MaterialDesignOutlinedComboBox}"
+                                                  materialDesign:HintAssist.Hint="{DynamicResource Common_Required}"
+                                                  IsEditable="True"
+                                                  IsTextSearchEnabled="True"
+                                                  StaysOpenOnEdit="True"
+                                                  TextSearch.TextPath="Name"
+                                                  DisplayMemberPath="Name"
+                                                  SelectedValuePath="Id"
+                                                  SelectionChanged="MatCategory_SelectionChanged" />
+                                        <Button Grid.Column="1"
+                                                Margin="8,0,0,0"
+                                                Style="{StaticResource TinyIconButton}"
+                                                Width="32"
+                                                Height="32"
+                                                Background="#3f51b5"
+                                                Click="AddCategory_Click"
+                                                ToolTip="{DynamicResource AdminHubView_AddCategoryTooltip}">
+                                            <iconPacks:PackIconFontAwesome Kind="PlusSolid" Width="14" Height="14" Foreground="White"/>
+                                        </Button>
+                                    </Grid>
                                 </DockPanel>
                                 <DockPanel Margin="0,0,0,8">
                                     <TextBlock Text="{DynamicResource AdminHubView_Unit}" Width="120" VerticalAlignment="Center"/>

--- a/Kanstraction/Views/OperationsView.xaml
+++ b/Kanstraction/Views/OperationsView.xaml
@@ -412,6 +412,7 @@
                 PreparingCellForEdit="MaterialsGrid_PreparingCellForEdit">
                 <DataGrid.Columns>
                     <DataGridTextColumn IsReadOnly="True" Header="{DynamicResource OperationsView_MaterialHeader}" Binding="{Binding Material.Name}"/>
+                    <DataGridTextColumn IsReadOnly="True" Header="{DynamicResource OperationsView_Category}" Binding="{Binding Material.MaterialCategory.Name}" Width="160"/>
                     <DataGridTextColumn Header="{DynamicResource OperationsView_Qty}" Width="100" IsReadOnly="False"
                         Binding="{Binding Qty, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged, StringFormat={}{0:0.##}}"/>
                     <DataGridTextColumn IsReadOnly="True" Header="{DynamicResource OperationsView_Unit}" Binding="{Binding Material.Unit}"/>

--- a/Kanstraction/Views/OperationsView.xaml.cs
+++ b/Kanstraction/Views/OperationsView.xaml.cs
@@ -129,6 +129,8 @@ public partial class OperationsView : UserControl
         var usages = await _db.MaterialUsages
             .Include(mu => mu.Material)
                 .ThenInclude(m => m.PriceHistory)
+            .Include(mu => mu.Material)
+                .ThenInclude(m => m.MaterialCategory)
             .Where(mu => mu.SubStageId == subStage.Id)
             .OrderBy(mu => mu.Material.Name)
             .ToListAsync();


### PR DESCRIPTION
## Summary
- add a MaterialCategory entity, hook up the relationship in the context, and seed a default French category through a new migration
- let admins select, filter, and create categories for materials while persisting the choice on save
- surface material category details in the stage preset designer, operations materials grid, and add-material dialog with localized labels
- rename the seeded default material category to "Defaut" to match the requested naming

## Testing
- not run (dotnet CLI is unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68e56803b60c832daefb77bb888e755b